### PR TITLE
Implement CoachAI scorecard skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Thor
+# CoachAI Hospice Scorecard
+
+This project implements a minimal prototype of the CoachAI hospice sales scorecard
+system.  It exposes helper functions for calculating performance metrics and
+producing scorecard data structures.
+
+Run the unit tests with:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema
+pytest

--- a/schema/hospiceScorecard.schema.json
+++ b/schema/hospiceScorecard.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Hospice Scorecard",
+  "type": "object",
+  "required": ["schemaVersion", "reportId", "generatedAt", "inputSnapshot", "growthAndActionPlan", "privateTrainerAnalysis"],
+  "properties": {
+    "schemaVersion": {"type": "string", "enum": ["1.0.0"]},
+    "reportId": {"type": "string", "format": "uuid"},
+    "generatedAt": {"type": "string", "format": "date-time"},
+    "inputSnapshot": {"type": "object"},
+    "growthAndActionPlan": {
+      "type": "object",
+      "required": ["pillarRatings"],
+      "properties": {
+        "pillarRatings": {
+          "type": "array",
+          "items": {"type": "number"},
+          "minItems": 5,
+          "maxItems": 5
+        }
+      }
+    },
+    "privateTrainerAnalysis": {
+      "type": "object",
+      "required": ["performanceIndexScore", "calculationBreakdown"],
+      "properties": {
+        "performanceIndexScore": {"type": "number"},
+        "calculationBreakdown": {
+          "type": "object",
+          "required": ["pillarAverage", "qualitativeScore", "quantitativeScore", "discretionaryScore"],
+          "properties": {
+            "pillarAverage": {"type": "number"},
+            "qualitativeScore": {"type": "number"},
+            "quantitativeScore": {"type": "number"},
+            "discretionaryScore": {"type": "number"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/coachai/scorecard.py
+++ b/src/coachai/scorecard.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from typing import Dict, Any, List
+
+
+def compute_ratio(goal: float, actual: float) -> float:
+    if goal <= 0:
+        return 0.0
+    return actual / goal
+
+
+def compute_pillar_average(ratings: List[float]) -> float:
+    if not ratings:
+        return 0.0
+    return sum(ratings) / len(ratings)
+
+
+def compute_qualitative_score(pillar_average: float) -> float:
+    return pillar_average * 12
+
+
+def compute_quantitative_score(ratios: List[float]) -> float:
+    if not ratios:
+        return 0.0
+    avg_ratio = sum(ratios) / len(ratios)
+    score = avg_ratio * 20
+    return min(score, 20)
+
+
+def compute_discretionary_score(discretionary: float) -> float:
+    return discretionary * 4
+
+
+def compute_performance_index_score(qualitative: float, quantitative: float, discretionary: float) -> float:
+    return qualitative + quantitative + discretionary
+
+
+def generate_report_id() -> str:
+    return str(uuid.uuid4())
+
+
+def current_timestamp() -> str:
+    return datetime.utcnow().isoformat() + "Z"
+
+
+def generate_scorecard(input_payload: Dict[str, Any]) -> Dict[str, Any]:
+    quantitative = input_payload.get("quantitativeMetrics", {})
+    sales_ratio = compute_ratio(quantitative.get("salesCalls", {}).get("goal", 0),
+                                quantitative.get("salesCalls", {}).get("actual", 0))
+    referrals_ratio = compute_ratio(quantitative.get("referrals", {}).get("goal", 0),
+                                    quantitative.get("referrals", {}).get("actual", 0))
+    admissions_ratio = compute_ratio(quantitative.get("admissions", {}).get("goal", 0),
+                                     quantitative.get("admissions", {}).get("actual", 0))
+
+    ratios = [sales_ratio, referrals_ratio, admissions_ratio]
+
+    # Placeholder ratings from trainer notes - default to 3
+    ratings = [3.0] * 5
+    pillar_average = compute_pillar_average(ratings)
+
+    qualitative_score = compute_qualitative_score(pillar_average)
+    quantitative_score = compute_quantitative_score(ratios)
+    discretionary_score = compute_discretionary_score(input_payload.get("discretionaryCoachScore", 0))
+
+    performance_index = compute_performance_index_score(
+        qualitative_score, quantitative_score, discretionary_score
+    )
+
+    scorecard = {
+        "schemaVersion": "1.0.0",
+        "reportId": generate_report_id(),
+        "generatedAt": current_timestamp(),
+        "inputSnapshot": input_payload,
+        "growthAndActionPlan": {
+            "pillarRatings": ratings,
+        },
+        "privateTrainerAnalysis": {
+            "performanceIndexScore": performance_index,
+            "calculationBreakdown": {
+                "pillarAverage": pillar_average,
+                "qualitativeScore": qualitative_score,
+                "quantitativeScore": quantitative_score,
+                "discretionaryScore": discretionary_score,
+            },
+        },
+    }
+    return scorecard

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,0 +1,29 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import math
+from coachai import scorecard
+
+
+def test_compute_ratio():
+    assert scorecard.compute_ratio(10, 5) == 0.5
+    assert scorecard.compute_ratio(0, 5) == 0.0
+
+
+def test_pillar_average():
+    ratings = [3, 4, 5]
+    assert math.isclose(scorecard.compute_pillar_average(ratings), 4.0)
+
+
+def test_scores():
+    ratios = [1.0, 0.5, 0.0]
+    pillar_avg = 3.0
+    qualitative = scorecard.compute_qualitative_score(pillar_avg)
+    quantitative = scorecard.compute_quantitative_score(ratios)
+    discretionary = scorecard.compute_discretionary_score(4)
+    performance = scorecard.compute_performance_index_score(
+        qualitative, quantitative, discretionary
+    )
+    assert qualitative == 36
+    assert quantitative == 10
+    assert discretionary == 16
+    assert performance == 62

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,40 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import json
+from jsonschema import validate
+from coachai import scorecard
+from pathlib import Path
+
+SCHEMA_PATH = Path("schema/hospiceScorecard.schema.json")
+
+
+def load_schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def example_input():
+    return {
+        "repName": "Jane Doe",
+        "reportDate": "2024-01-01",
+        "trainerNotes": {
+            "preCallPlanning": "solid work",
+            "consultativeSalesModel": "good job",
+            "clinicalAcumenAndValue": "nice",
+            "territoryManagement": "ok",
+            "mindsetAndProfessionalism": "great"
+        },
+        "quantitativeMetrics": {
+            "salesCalls": {"goal": 10, "actual": 8, "reasonIfMissed": ""},
+            "referrals": {"goal": 5, "actual": 4, "reasonIfMissed": ""},
+            "admissions": {"goal": 3, "actual": 2, "reasonIfMissed": ""}
+        },
+        "discretionaryCoachScore": 4
+    }
+
+
+def test_generate_scorecard_schema():
+    data = example_input()
+    card = scorecard.generate_scorecard(data)
+    schema = load_schema()
+    validate(card, schema)


### PR DESCRIPTION
## Summary
- implement basic scorecard calculations in `coachai/scorecard.py`
- define validation schema `hospiceScorecard.schema.json`
- add pytest unit tests for calculation logic and schema validation
- document project usage in `README.md`
- add requirements and `.gitignore`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868919c0a9883248358ee6016b995e6